### PR TITLE
logica buscar y endpoint

### DIFF
--- a/chef_planner/pom.xml
+++ b/chef_planner/pom.xml
@@ -42,6 +42,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeDetailsResponse.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeDetailsResponse.java
@@ -1,0 +1,27 @@
+package com.salesianostriana.chefplanner.recipes.Dto;
+
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
+import com.salesianostriana.chefplanner.recipes.model.Recipe;
+
+public record RecipeDetailsResponse(
+        String title,
+        String description,
+        int minutes,
+        Difficulty difficulty,
+        boolean featured,
+        String authorName,
+        List<IngredientResponse> ingredients
+){
+    public static RecipeDetailsResponse fromEntity(Recipe recipe) {
+        return new RecipeDetailsResponse(
+                recipe.getTitle(),
+                recipe.getDescription(),
+                (int) recipe.getMinutes().toMinutes(),
+                recipe.getDifficulty(),
+                recipe.isFeatured(),
+                recipe.getAuthor() != null ? recipe.getAuthor().getName() : "Anónimo",
+                recipe.getIngredients().stream()
+                        .map(IngredientResponse::fromEntity)
+                        .toList()
+        );
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeRequest.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeRequest.java
@@ -1,0 +1,32 @@
+package com.salesianostriana.chefplanner.recipes.Dto;
+
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
+import com.salesianostriana.chefplanner.recipes.model.Recipe;
+import com.salesianostriana.chefplanner.recipes.validation.ValidDifficulty;
+import com.salesianostriana.chefplanner.recipes.validation.ValidMinutes;
+import jakarta.validation.constraints.*;
+import org.apache.catalina.User;
+
+import java.time.Duration;
+
+public record RecipeRequest (
+        @NotBlank String title,
+        String description,
+        @ValidMinutes
+        Duration minutes,
+        @ValidDifficulty
+        Difficulty difficulty,
+        @NotNull
+        boolean featured
+) {
+    public Recipe toEntity() {
+        return Recipe.builder()
+                .title(this.title)
+                .description(this.description)
+                .minutes(Duration.ofMinutes(this.minutes.toMinutes()))
+                .difficulty(difficulty)
+                .featured(false)
+                .build();
+    }
+
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeResponse.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeResponse.java
@@ -1,0 +1,25 @@
+package com.salesianostriana.chefplanner.recipes.Dto;
+
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
+import com.salesianostriana.chefplanner.recipes.model.Recipe;
+
+import java.time.Duration;
+
+public record RecipeResponse(
+        String title,
+        Duration minutes,
+        Difficulty difficulty,
+        boolean featured,
+        String authorName
+) {
+
+    public static RecipeResponse fromEntity(Recipe recipe) {
+        return new RecipeResponse(
+                recipe.getTitle(),
+                recipe.getMinutes().toMinutes(),
+                recipe.getDifficulty(),
+                recipe.isFeatured(),
+                recipe.getAuthor() != null ? recipe.getAuthor().getName() : "Anónimo"
+        );
+    }
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
@@ -1,0 +1,83 @@
+package com.salesianostriana.chefplanner.recipes.controller;
+
+import com.salesianostriana.chefplanner.recipes.Dto.RecipeResponse;
+import com.salesianostriana.chefplanner.recipes.model.Recipe;
+import com.salesianostriana.chefplanner.recipes.service.RecipeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("api/v1/recipes")
+@RequiredArgsConstructor
+@Tag(name = "Recetas", description = "Gestión de recetas de cocina")
+
+public class RecipeController {
+
+    private final RecipeService service;
+
+
+
+
+
+
+
+    @GetMapping("/buscar")
+    @Operation(summary = "Buscar recetas por texto",
+            description = "Filtra las recetas cuyo título o descripción coincidan con el término proporcionado.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Se han encontrado recetas",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = RecipeResponse.class)),
+                            examples = @ExampleObject(value = """
+                                    [
+                                        {
+                                            "id": 1,
+                                            "title": "Pasta Carbonara Tradicional",
+                                            "minutes": 15,
+                                            "difficulty": "EASY",
+                                            "featured": true,
+                                            "authorName": "Juan Pérez"
+                                        },
+                                        {
+                                            "id": 5,
+                                            "title": "Ensalada César",
+                                            "minutes": 10,
+                                            "difficulty": "EASY",
+                                            "featured": false,
+                                            "authorName": "Ana García"
+                                        }
+                                    ]
+                                    """)
+                    )
+            )
+    })
+    public List<RecipeResponse> search(
+            @Parameter(description = "Término de búsqueda (título o descripción)", example = "pasta")
+            @RequestParam(name = "s") String term) {
+
+        return service.searchRecipesWithStreams(term).stream()
+                .map(RecipeResponse::fromEntity)
+                .toList();
+    }
+
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/model/Difficulty.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/model/Difficulty.java
@@ -1,0 +1,7 @@
+package com.salesianostriana.chefplanner.recipes.model;
+
+public enum Difficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/model/Recipe.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/model/Recipe.java
@@ -1,0 +1,91 @@
+package com.salesianostriana.chefplanner.recipes.model;
+
+import com.salesianostriana.chefplanner.user.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "recipes")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter @Setter
+@Builder
+public class Recipe {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @NotNull
+    @JdbcTypeCode(SqlTypes.INTERVAL_SECOND)
+    private Duration minutes;
+
+
+    @Enumerated(EnumType.STRING)
+    private Difficulty difficulty;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private User author;
+
+
+    @Lob
+    @Basic(fetch = FetchType.LAZY)
+    private byte[] coverFileData;
+
+    private String coverFileType;
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private boolean featured = false;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecipeIngredient> ingredients = new ArrayList<>();
+
+
+    public void addIngredient(RecipeIngredient ingredient) {
+        ingredients.add(ingredient);
+        ingredient.setRecipe(this);
+    }
+
+    public void removeIngredient(RecipeIngredient ingredient) {
+        ingredients.remove(ingredient);
+        ingredient.setRecipe(null);
+    }
+
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Class<?> oEffectiveClass = o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass() : o.getClass();
+        Class<?> thisEffectiveClass = this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) return false;
+        Recipe recipe = (Recipe) o;
+        return getId() != null && Objects.equals(getId(), recipe.getId());
+    }
+
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
+    }
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/repository/RecipeRepository.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/repository/RecipeRepository.java
@@ -1,0 +1,24 @@
+package com.salesianostriana.chefplanner.recipes.repository;
+
+
+import com.salesianostriana.chefplanner.recipes.model.Recipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+    Page<Recipe> findByAuthorId(Long authorId, Pageable pageable);
+
+    @Transactional(readOnly = true)
+    @Query("SELECT r" +
+            " FROM Recipe r" +
+            " WHERE r.featured = true")
+    Page<Recipe> findFeaturedRecipes(Pageable pageable);
+
+    Page<Recipe> findByFeaturedTrue(Pageable pageable);
+
+
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/service/RecipeService.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/service/RecipeService.java
@@ -1,0 +1,80 @@
+package com.salesianostriana.chefplanner.recipes.service;
+
+import com.salesianostriana.chefplanner.recipes.Dto.RecipeRequest;
+import com.salesianostriana.chefplanner.recipes.repository.RecipeRepository;
+import com.salesianostriana.chefplanner.recipes.model.Recipe;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecipeService {
+    private final RecipeRepository repository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Recipe save(Recipe recipe, Long authorId) {
+
+        recipe.setAuthor(userRepository.getReferenceById(authorId));
+
+        return repository.save(recipe);
+    }
+
+    public Page<Recipe> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<Recipe> findMyRecipes(Long authorId, Pageable pageable) {
+        return repository.findByAuthorId(authorId, pageable);
+    }
+
+    public Recipe findById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Receta no encontrada"));
+    }
+
+    @Transactional
+    public Recipe edit(Long id, Recipe recipe) {
+
+        Recipe originalRecipe = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Receta no encontrada"));
+
+        originalRecipe.setTitle(recipe.getTitle());
+        originalRecipe.setDescription(recipe.getDescription());
+        originalRecipe.setMinutes(recipe.getMinutes());
+        originalRecipe.setDifficulty(recipe.getDifficulty());
+
+        return originalRecipe;
+
+    }
+    //Buscar por texto
+    public List<Recipe> searchRecipesWithStreams(String texto) {
+        return repository.findAll()
+                .stream()
+                .filter(r -> r.getTitle().toLowerCase().contains(texto.toLowerCase()))
+                .toList();
+    }
+
+    @Transactional
+    public void deleteById(Long id) {
+        if (repository.existsById(id)) {
+            repository.deleteById(id);
+        }
+    }
+
+    @Transactional
+    public void toggleFeatured(Long id) {
+        Recipe recipe = findById(id);
+        recipe.setFeatured(!recipe.isFeatured());
+    }
+
+
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/DifficultyValidator.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/DifficultyValidator.java
@@ -1,0 +1,14 @@
+package com.salesianostriana.chefplanner.recipes.validation;
+
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class DifficultyValidator implements ConstraintValidator<ValidDifficulty, Difficulty> {
+
+    @Override
+    public boolean isValid(Difficulty value, ConstraintValidatorContext context) {
+
+        return value != null;
+    }
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/MinutesValidator.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/MinutesValidator.java
@@ -1,0 +1,13 @@
+package com.salesianostriana.chefplanner.recipes.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.Duration;
+
+public class MinutesValidator implements ConstraintValidator<ValidMinutes, Duration> {
+    @Override
+    public boolean isValid(Duration value, ConstraintValidatorContext context) {
+        return value != null && !value.isNegative() && !value.isZero();
+    }
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/ValidDifficulty.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/ValidDifficulty.java
@@ -1,0 +1,16 @@
+package com.salesianostriana.chefplanner.recipes.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DifficultyValidator.class)
+@Documented
+public @interface ValidDifficulty {
+    String message() default "La dificultad debe ser EASY, MEDIUM o HARD";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/ValidMinutes.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/validation/ValidMinutes.java
@@ -1,0 +1,17 @@
+package com.salesianostriana.chefplanner.recipes.validation;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MinutesValidator.class)
+@Documented
+public @interface ValidMinutes {
+    String message() default "El tiempo debe ser un valor positivo mayor a 0";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
This pull request introduces the core backend structure for recipe management in the application, including the data model, DTOs, validation, repository, service, and a controller endpoint for searching recipes. It also adds OpenAPI documentation support for API endpoints. The changes lay the foundation for CRUD operations and validation logic around recipes.

**Recipe domain and persistence:**

* Added the `Recipe` entity with fields for title, description, duration, difficulty, author, ingredients, and cover image, along with proper JPA annotations and relationships. Also introduced the `Difficulty` enum. [[1]](diffhunk://#diff-b7d38f21eda86a7300e4a5a68113e9a37a5c9d9245a29046e0ce31d753341b13R1-R91) [[2]](diffhunk://#diff-ab7e717f48590fa51b00743540f53ca76fda0a670f28ceea1ad34ac6a9a925c7R1-R7)
* Implemented `RecipeRepository` with methods for finding recipes by author, by featured status, and a custom query for featured recipes.

**DTOs and mapping:**

* Created `RecipeRequest`, `RecipeResponse`, and `RecipeDetailsResponse` DTOs with mapping methods to and from the `Recipe` entity, supporting both input validation and API responses. [[1]](diffhunk://#diff-d9a9f4cea9321512aefb0536465730d482462d31dbd8d8a05ccc9b783dd83065R1-R32) [[2]](diffhunk://#diff-ddd3e9c0d4d0b531c96c2de6afae5e2ccb53905ec05f8ab167e569464a3b3d61R1-R25) [[3]](diffhunk://#diff-49451b74e1f4925ac269b4fafdceb1cafb2e3cd87799546d4e73dd4c22d4672dR1-R27)

**Validation:**

* Introduced custom validation annotations and validators for recipe difficulty (`@ValidDifficulty`) and minutes (`@ValidMinutes`), ensuring data integrity for incoming requests. [[1]](diffhunk://#diff-eb4dc0ffed1ededb4af16bbe0cf2fe346879be42291b16f542f6c09eba37db34R1-R16) [[2]](diffhunk://#diff-d0c0895a17f2b3a753efe98d5ce3a120583dfea2fd49130d758b74e6aee83ec5R1-R14) [[3]](diffhunk://#diff-45d4fcad2b44a59e763502445b8e4e8ac9265eadd0542e61cf5cf3b72fa9933cR1-R17) [[4]](diffhunk://#diff-991a82e806688dfbf3904153527dd663f63769c91d9c98fe8ed3fe497f874592R1-R13)

**Service and business logic:**

* Added `RecipeService` with methods for saving, editing, deleting, toggling featured status, and searching recipes by text, encapsulating business rules and repository access.

**API and documentation:**

* Implemented `RecipeController` with a `/buscar` endpoint to search recipes by text, including OpenAPI/Swagger documentation for better API discoverability.
* Added the `springdoc-openapi-starter-webmvc-ui` dependency to enable Swagger UI for API documentation.

Por algun motivo pone que he  metido todo eso cuando solo he metido la lofica de buscar receta por texto