### PR TITLE
crear y borrar

### DIFF
--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
@@ -18,6 +18,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,11 +33,6 @@ import java.util.List;
 public class RecipeController {
 
     private final RecipeService service;
-
-
-
-
-
 
 
     @GetMapping("/buscar")
@@ -140,7 +137,7 @@ public class RecipeController {
                     description = "Se han encontrado recetas",
                     content = @Content(
                             mediaType = "application/json",
-                            
+
                             array = @ArraySchema(schema = @Schema(implementation = RecipeResponse.class)),
                             examples = @ExampleObject(value = """
                                     {
@@ -219,4 +216,84 @@ public class RecipeController {
         return RecipeDetailsResponse.fromEntity(updatedRecipe);
     }
 
+    @PostMapping ("/crear")
+    @Operation(summary = "Endpoint para crear y guardar una nueva receta",
+            description = "Crea una receta a partir de los datos del cuerpo de la petición y la asocia a un autor existente. " +
+                    "Devuelve el detalle completo de la receta creada.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "La receta se ha creado correctamente",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = RecipeDetailsResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "id": 1,
+                                        "title": "Pasta Carbonara Tradicional",
+                                        "description": "Receta clásica con guanciale y pecorino",
+                                        "minutes": 15,
+                                        "difficulty": "EASY",
+                                        "featured": true,
+                                        "authorName": "Chef Pro",
+                                        "ingredients": [
+                                            {
+                                                "name": "Espaguetis",
+                                                "quantity": 200.0,
+                                                "unit": "g"
+                                            }
+                                        ]
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Los datos de la receta no son válidos",
+                    content = @Content
+            )
+    })
+    public ResponseEntity<RecipeDetailsResponse> save(
+            @Valid @RequestBody RecipeRequest recipeRequest,
+            @Parameter(description = "ID del autor de la receta", example = "1")
+            @RequestParam Long authorId) {
+
+        Recipe recipe = recipeRequest.toEntity();
+        Recipe savedRecipe = service.save(recipe, authorId);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(RecipeDetailsResponse.fromEntity(savedRecipe));
+    }
+
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Eliminar una receta",
+            description = "Elimina de forma permanente una receta y sus ingredientes asociados de la base de datos.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "La receta ha sido eliminada con éxito",
+                    content = @Content 
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "No se pudo eliminar: la receta no existe",
+                    content = @Content
+            )
+    })
+    public ResponseEntity<Void> delete(
+            @Parameter(description = "ID de la receta a eliminar", example = "1")
+            @PathVariable Long id) {
+        service.deleteById(id);
+
+        return ResponseEntity.noContent().build();
+    }
+
+
 }
+
+
+
+
+


### PR DESCRIPTION
This pull request adds new endpoints to the `RecipeController` to support creating and deleting recipes, along with improved API documentation. It also includes some minor clean-up and import additions.

**New endpoints and API improvements:**

* Added a `POST /crear` endpoint to create and save a new recipe, associating it with an existing author. The endpoint returns the full details of the created recipe and includes detailed Swagger documentation and response examples.
* Added a `DELETE /{id}` endpoint to permanently delete a recipe and its associated ingredients, with appropriate Swagger documentation for success and error responses.

**Supporting changes:**

* Imported `HttpStatus` and `ResponseEntity` to support the new endpoints' response handling.
* Minor code clean-up by removing extra blank lines for improved readability.