### PR TITLE
filtro recetas

### DIFF
--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeSearchRequest.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/Dto/RecipeSearchRequest.java
@@ -1,0 +1,15 @@
+package com.salesianostriana.chefplanner.recipes.Dto;
+
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Criterios para el filtrado de recetas")
+public record RecipeSearchRequest(
+        @Parameter(description = "Nivel de dificultad", example = "EASY")
+        Difficulty difficulty,
+
+        @Parameter(description = "Tiempo máximo de preparación en minutos", example = "30")
+        Integer maxMinutes
+) {
+}

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
@@ -3,6 +3,8 @@ package com.salesianostriana.chefplanner.recipes.controller;
 import com.salesianostriana.chefplanner.recipes.Dto.RecipeDetailsResponse;
 import com.salesianostriana.chefplanner.recipes.Dto.RecipeRequest;
 import com.salesianostriana.chefplanner.recipes.Dto.RecipeResponse;
+import com.salesianostriana.chefplanner.recipes.Dto.RecipeSearchRequest;
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
 import com.salesianostriana.chefplanner.recipes.model.Recipe;
 import com.salesianostriana.chefplanner.recipes.service.RecipeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -288,6 +291,26 @@ public class RecipeController {
         service.deleteById(id);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/filter")
+    @Operation(summary = "Filtrado avanzado con DTO",
+            description = "Recibe un objeto con múltiples criterios de búsqueda opcionales.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Resultados obtenidos satisfactoriamente",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = RecipeResponse.class))
+                    )
+            )
+    })
+    public List<RecipeResponse> filter(RecipeSearchRequest search) {
+
+        return service.buscarRecetasConDTO(search).stream()
+                .map(RecipeResponse::fromEntity)
+                .toList();
     }
 
 

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/model/Recipe.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/model/Recipe.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.type.SqlTypes;
+import org.springframework.data.jpa.domain.PredicateSpecification;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -89,4 +90,16 @@ public class Recipe {
     public final int hashCode() {
         return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer().getPersistentClass().hashCode() : getClass().hashCode();
     }
+
+    public static class Specs{
+        public static PredicateSpecification<Recipe> dificultad(Difficulty difficulty) {
+            return (from, criteriaBuilder) ->
+                    difficulty == null ? null : criteriaBuilder.equal(from.get("difficulty"), difficulty);
+        }
+        public static PredicateSpecification<Recipe> tiempoMaximo(Duration maxTime) {
+            return (from, criteriaBuilder) ->
+                    maxTime == null ? null : criteriaBuilder.lessThanOrEqualTo(from.get("minutes"), maxTime);
+        }
+    }
+
 }

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/repository/RecipeRepository.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/repository/RecipeRepository.java
@@ -5,10 +5,11 @@ import com.salesianostriana.chefplanner.recipes.model.Recipe;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+public interface RecipeRepository extends JpaRepository<Recipe, Long>, JpaSpecificationExecutor<Recipe> {
 
     Page<Recipe> findByAuthorId(Long authorId, Pageable pageable);
 

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/service/RecipeService.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/service/RecipeService.java
@@ -1,5 +1,7 @@
 package com.salesianostriana.chefplanner.recipes.service;
 
+import com.salesianostriana.chefplanner.recipes.Dto.RecipeSearchRequest;
+import com.salesianostriana.chefplanner.recipes.model.Difficulty;
 import com.salesianostriana.chefplanner.recipes.repository.RecipeRepository;
 import com.salesianostriana.chefplanner.recipes.model.Recipe;
 import com.salesianostriana.chefplanner.user.UserRepository;
@@ -10,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -40,6 +43,20 @@ public class RecipeService {
     public Recipe findById(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Receta no encontrada"));
+    }
+
+
+    //filtro
+    public List<Recipe> buscarRecetasConDTO(RecipeSearchRequest search) {
+
+        Duration duration = (search.maxMinutes() != null)
+                ? Duration.ofMinutes(search.maxMinutes())
+                : null;
+
+        return repository.findAll(
+                Recipe.Specs.dificultad(search.difficulty())
+                        .and(Recipe.Specs.tiempoMaximo(duration))
+        );
     }
 
     @Transactional


### PR DESCRIPTION
This pull request introduces an advanced recipe filtering feature using a new DTO (`RecipeSearchRequest`) that allows clients to filter recipes by difficulty and maximum preparation time. The implementation includes controller, service, model, and repository changes to support flexible querying using specifications.

**Advanced Filtering Feature:**

* Added a new DTO, `RecipeSearchRequest`, to encapsulate optional filtering criteria such as `difficulty` and `maxMinutes` for recipe searches.
* Implemented a new `/filter` endpoint in `RecipeController` that accepts the DTO and returns filtered recipes using the new service method.
* Enhanced `RecipeService` with a `buscarRecetasConDTO` method that builds and applies specifications based on the DTO fields.

**Specification-based Querying:**

* Introduced static specification methods (`dificultad`, `tiempoMaximo`) in `Recipe.Specs` for building dynamic JPA queries based on difficulty and preparation time.
* Updated `RecipeRepository` to extend `JpaSpecificationExecutor<Recipe>`, enabling the use of specifications for advanced queries.