### PR TITLE
F.32  dockerfile y dockerignore

### DIFF
--- a/chef_planner/.dockerignore
+++ b/chef_planner/.dockerignore
@@ -1,0 +1,24 @@
+# Maven / build
+target/
+**/target/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+.project
+.classpath
+.settings/
+
+# Git
+.git/
+.gitignore
+
+# OS
+.DS_Store
+
+# Logs
+*.log
+
+# Docker
+docker-compose*.yml

--- a/chef_planner/DockerFile
+++ b/chef_planner/DockerFile
@@ -1,0 +1,43 @@
+# =========================
+# Stage 1: build (Maven + JDK 21)
+# =========================
+FROM maven:3-eclipse-temurin-21 AS build
+WORKDIR /app
+
+# Copiamos primero lo mínimo para cachear dependencias
+COPY pom.xml ./
+COPY .mvn/ .mvn/
+COPY mvnw ./
+
+# Asegurar permisos + evitar CRLF en mvnw
+RUN chmod +x mvnw && sed -i 's/\r$//' mvnw
+
+# Descargar dependencias (mejor caché)
+RUN ./mvnw -DskipTests dependency:go-offline
+
+# Copiamos el código y compilamos
+COPY src/ src/
+RUN ./mvnw -DskipTests package
+
+# =========================
+# Stage 2: runtime (JRE 21)
+# =========================
+FROM eclipse-temurin:21-jre-alpine AS runtime
+WORKDIR /app
+
+# Usuario no-root
+RUN addgroup -S spring && adduser -S spring -G spring
+
+# Copiar jar
+COPY --from=build /app/target/*.jar /app/app.jar
+
+# Copiar entrypoint
+COPY ./docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+USER spring:spring
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom"
+EXPOSE 8080
+
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
This pull request adds IntelliJ IDEA project configuration files and sets up the Java/Maven environment for the project. The changes include IDE-specific settings, Maven repository configurations, and the addition of library definitions for all project dependencies.

IDE configuration:

* Added default `.gitignore` entries for IDEA to exclude workspace and shelf files.
* Added IDEA project and module files, including `ChefPlanner_back.iml`, encoding settings, annotation processing, and migration state. [[1]](diffhunk://#diff-a6917746497bb981fa3d37b20e4af7a71ac648d64696f38ce17743d2e76b65ecR1-R9) [[2]](diffhunk://#diff-8cb3412a492e2ae9665f4b017977eaec9f1a66b9d23b1c2fe11bab6d790c2befR1-R6) [[3]](diffhunk://#diff-2bb695a627709c0ba8d2645880396ff81d5f9f7ce16b2577cd9df1ea6f3b04b5R1-R21) [[4]](diffhunk://#diff-e5d9a6c923b4b054af0508e997183314be9401f8315f3c3147c88053bc1cf704R1-R6)

Maven repository and dependency setup:

* Configured remote Maven repositories in `jarRepositories.xml` for dependency resolution, including Maven Central and JBoss repositories.
* Added library definitions for all Maven dependencies used in the project under `.idea/libraries/`, enabling IntelliJ to recognize and manage these dependencies. [[1]](diffhunk://#diff-367a60f0e42bce5af8f6ff577fed58c6200e2b7760678c70a0c3db9a6fc12618R1-R14) [[2]](diffhunk://#diff-e3f7853dafc09d67885b8ba41f91b75f364d50bdd356b2486ac611ac55cbe4a2R1-R14) [[3]](diffhunk://#diff-156ab610e8289cd631681116b58f8c9d44179a6b7ce74357f70cf5df5bbbe3b3R1-R14) [[4]](diffhunk://#diff-584900f02b37499af87deda5855a072669bf675771a7783b0371a133d6160407R1-R14) [[5]](diffhunk://#diff-4f5b3e2af3f4fb627117efc1ba80224b25e8bb2d25a5ed0436505b90426127e6R1-R14) [[6]](diffhunk://#diff-6c0b17b7ee6bfb5d336de63059651f7ca8ad127f7a6e6b10ee95a5aa36f6281bR1-R14) [[7]](diffhunk://#diff-5d61f2170c0d9dd3fbe31cf853eb7b4aefc6d14a28846ba06afecb9e9d9d28a1R1-R14) [[8]](diffhunk://#diff-4b4ba441370bc6d4ad095f2de35e1f7515acfd525dde4b85020f29fd274fc13cR1-R14) [[9]](diffhunk://#diff-7607607475f3042c251706d148f48bd1806797dfa9da5a965bccd92042bb0db1R1-R14) [[10]](diffhunk://#diff-5be650a6082ba48677bcd59037feaadb12323ae934ccd73bb9aa157b08607d47R1-R14) [[11]](diffhunk://#diff-a2776796fd3e56e4a6c98822f040ff2150d8438a23b4417f1d48cbdb5bfc2836R1-R14) [[12]](diffhunk://#diff-f4fc3ab71d899d10827753bc0d65963c9ef1f7760e9ecd3a5735e715b8f1758bR1-R14) [[13]](diffhunk://#diff-5d3b289598e99f07c002b18a26a8716a4bd42e9548a61921fd0895ce2e5fa84dR1-R14) [[14]](diffhunk://#diff-18fb888afc870f52dcefa453bbb292368cf4fe72772f5c74c34874d3872ba133R1-R14)