### PR TITLE
feat-26 : Desarrolo de métodos para eliminar receta tanto para ADMIN …

### DIFF
--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/ingredient/controller/IngredientController.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/ingredient/controller/IngredientController.java
@@ -76,7 +76,7 @@ public class IngredientController {
             ),
 
     })
-    @GetMapping("admin/ingredient/search")
+    @GetMapping("/admin/ingredient/search")
     public Page<IngredientResponse> filtrarIngredientes(@PageableDefault(page = 0,size = 20,sort = "name",direction = Sort.Direction.DESC) Pageable pageable,
                                                         @RequestParam(required = false) String name){
         return ingredientService.mostrarFiltrados(name,pageable).map(IngredientResponse::of);
@@ -141,13 +141,13 @@ public class IngredientController {
                     )
             )
     })
-    @PostMapping("admin/ingredient/add")
+    @PostMapping("/admin/ingredient/add")
     @PreAuthorize("hasRole('ADMIN')")
     public IngredientResponse addIngredient(@RequestBody IngredientRequest request) {
         return IngredientResponse.of(ingredientService.addIngredient(request));
     }
 
-    @DeleteMapping("/ingredient/delete/{id}")
+    @DeleteMapping("/admin/ingredient/delete/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public void deleteIngredient(@PathVariable Long id) {
         ingredientService.deleteIngredient(id);

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/controller/RecipeController.java
@@ -400,5 +400,16 @@ public class RecipeController {
         });
     }
 
-
+    @Operation(summary = "Eliminar una receta", description = "Elimina una receta específica por su ID. ")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Receta eliminada con éxito", content = @Content),
+        @ApiResponse(responseCode = "404", description = "No se encontró la receta con el ID proporcionado", content = @Content)
+    })
+    @DeleteMapping("recipe/delete/{id}")
+    public ResponseEntity<Void> deleteRecipe(
+            @Parameter(description = "ID de la receta a eliminar", example = "1")
+            @PathVariable Long id) {
+        service.deleteRecipe(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/service/RecipeService.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/recipes/service/RecipeService.java
@@ -1,8 +1,10 @@
 package com.salesianostriana.chefplanner.recipes.service;
 
 import com.salesianostriana.chefplanner.recipes.Dto.RecipeSearchRequest;
+import com.salesianostriana.chefplanner.recipes.error.RecipeNotFoundException;
 import com.salesianostriana.chefplanner.recipes.repository.RecipeRepository;
 import com.salesianostriana.chefplanner.recipes.model.Recipe;
+import com.salesianostriana.chefplanner.user.model.UserProfile;
 import com.salesianostriana.chefplanner.user.repository.UserProfileRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -105,6 +107,21 @@ public class RecipeService {
 
     public Page<Recipe> findByAuthor(String userUuid, Pageable pageable) {
         return repository.findByAuthorUserUuid(userUuid, pageable);
+    }
+
+
+    //Eliminar receta (ADMIN y User)
+    public void deleteRecipe(Long id) {
+        Recipe recipe = findById(id);
+        UserProfile userProfile = recipe.getAuthor();
+
+        if (repository.existsById(id)) {
+            userProfile.getRecipes().remove(recipe);
+            repository.deleteById(id);
+
+        } else {
+            throw new RecipeNotFoundException("Receta no encontrada");
+        }
     }
 
 }

--- a/chef_planner/src/main/java/com/salesianostriana/chefplanner/user/dto/LoginResponse.java
+++ b/chef_planner/src/main/java/com/salesianostriana/chefplanner/user/dto/LoginResponse.java
@@ -2,7 +2,7 @@ package com.salesianostriana.chefplanner.user.dto;
 
 import java.util.UUID;
 
-public record LoginResponse(
+public record   LoginResponse(
         String username,
         UUID userId,
         String token,


### PR DESCRIPTION
This pull request introduces several improvements and corrections to the ingredient and recipe management endpoints in the application. The main changes include standardizing admin route paths for ingredient operations, adding a new endpoint for deleting recipes with proper API documentation, and implementing the backend logic for recipe deletion with error handling.

**Ingredient endpoint path corrections:**

* Updated all ingredient-related admin endpoints in `IngredientController` to consistently use the `/admin/ingredient/` prefix, ensuring proper route organization and security. [[1]](diffhunk://#diff-7ee3ce74bdffc3341534dfdc4419499f0f78099600c7e0157313e9e272b8003aL79-R79) [[2]](diffhunk://#diff-7ee3ce74bdffc3341534dfdc4419499f0f78099600c7e0157313e9e272b8003aL144-R150)

**Recipe deletion feature:**

* Added a new `DELETE /recipe/delete/{id}` endpoint in `RecipeController` to allow deletion of recipes, including OpenAPI documentation for successful and not-found responses.
* Implemented the `deleteRecipe(Long id)` method in `RecipeService`, which removes the recipe from both the repository and the author's recipe list, and throws a `RecipeNotFoundException` if the recipe does not exist.
* Imported the necessary exception and model classes in `RecipeService` to support the new deletion logic.…como USER