### PR TITLE
fix-19.1 : arreglo de data.sql

### DIFF
--- a/chef_planner/src/main/resources/data.sql
+++ b/chef_planner/src/main/resources/data.sql
@@ -1,4 +1,18 @@
 -- =============================================
+-- LIMPIAR TABLAS (orden inverso por foreign keys)
+-- =============================================
+TRUNCATE TABLE menu_item,
+               user_pantry_ingredients,
+               recipe_ingredient,
+               recipes,
+               user_profiles,
+               user_roles,
+               ingredient,
+               users
+RESTART IDENTITY CASCADE;
+
+
+-- =============================================
 -- USERS
 -- =============================================
 INSERT INTO users (id, email, username, password)


### PR DESCRIPTION
This pull request adds a SQL script section to clear all relevant tables in the database, ensuring referential integrity by truncating them in reverse order of their foreign key dependencies. This is useful for resetting the database to a clean state during development or testing.

Database maintenance:

* Added a SQL block to `data.sql` that truncates the tables `menu_item`, `user_pantry_ingredients`, `recipe_ingredient`, `recipes`, `user_profiles`, `user_roles`, `ingredient`, and `users` in reverse order of foreign key dependencies, and restarts their identities with `CASCADE`.